### PR TITLE
Fix ARC-19 reserve address checksum validation and CIDv1 support

### DIFF
--- a/Sources/ARC/ARC19/ARC19CID.swift
+++ b/Sources/ARC/ARC19/ARC19CID.swift
@@ -42,25 +42,15 @@ public enum ARC19CID {
             throw ARCError.invalidURL("Invalid ARC-19 template placeholder format: \(placeholder)")
         }
 
-        // Parse version
-        let versionNum = Int(parts[1]) ?? 0
+        // Parse version with strict validation
+        let versionStr = String(parts[1])
+        guard let versionNum = Int(versionStr), versionNum == 0 || versionNum == 1 else {
+            throw ARCError.invalidURL("Unsupported CID version in ARC-19 template: \(versionStr)")
+        }
         let version: CID.Version = versionNum == 1 ? .v1 : .v0
 
-        // Parse codec
-        let codecStr = String(parts[2])
-        let codec: CID.Codec
-        switch codecStr {
-        case "raw":
-            codec = .raw
-        case "dag-pb":
-            codec = .dagPB
-        case "dag-cbor":
-            codec = .dagCBOR
-        case "dag-json":
-            codec = .dagJSON
-        default:
-            throw ARCError.invalidURL("Unsupported codec in ARC-19 template: \(codecStr)")
-        }
+        // Parse codec using extension
+        let codec = try CID.Codec(templateString: String(parts[2]))
 
         // Parse hash algorithm
         let hashAlgorithm = String(parts[4])
@@ -112,7 +102,7 @@ public enum ARC19CID {
             return .v0DagPB
         }
 
-        let placeholder = String(templateUrl[startRange.lowerBound...endRange.lowerBound])
+        let placeholder = String(templateUrl[startRange.lowerBound..<endRange.upperBound])
         return try parseTemplateParams(from: placeholder)
     }
 

--- a/Sources/ARC/ARC19/ARC19CID.swift
+++ b/Sources/ARC/ARC19/ARC19CID.swift
@@ -35,7 +35,7 @@ public enum ARC19CID {
         }
 
         let parts = content.split(separator: ":")
-        guard parts.count >= 5,
+        guard parts.count == 5,
               parts[0] == "ipfscid",
               parts[3] == "reserve"
         else {
@@ -52,8 +52,11 @@ public enum ARC19CID {
         // Parse codec using extension
         let codec = try CID.Codec(templateString: String(parts[2]))
 
-        // Parse hash algorithm
+        // Parse and validate hash algorithm (only sha2-256 is currently supported)
         let hashAlgorithm = String(parts[4])
+        guard hashAlgorithm == "sha2-256" else {
+            throw ARCError.invalidURL("Unsupported hash algorithm in ARC-19 template: \(hashAlgorithm). Only sha2-256 is currently supported.")
+        }
 
         return TemplateParams(version: version, codec: codec, hashAlgorithm: hashAlgorithm)
     }
@@ -82,11 +85,22 @@ public enum ARC19CID {
         return CID(version: params.version, codec: params.codec, hash: hash)
     }
 
-    /// Extract a CID from an Algorand reserve address using template URL to determine parameters
+    /// Extract a CID from an Algorand reserve address by parsing the template URL for CID parameters.
+    ///
+    /// This method parses the template URL to extract CID version and codec information from the
+    /// `{ipfscid:...}` placeholder, then uses those parameters to construct the CID from the
+    /// reserve address. Use this when you have a template URL and want automatic parameter extraction.
+    ///
+    /// For explicit control over CID parameters, use `extractCID(from:params:validateChecksum:)` instead.
+    ///
+    /// - Note: If the template URL doesn't contain a valid `{ipfscid:...}` placeholder,
+    ///   this method defaults to CIDv0 with dag-pb codec.
+    ///
     /// - Parameters:
-    ///   - address: The Algorand reserve address containing the encoded CID
-    ///   - templateUrl: The template URL containing the placeholder with version/codec info
-    /// - Returns: The extracted CID
+    ///   - address: The Algorand reserve address containing the encoded CID hash
+    ///   - templateUrl: The template URL containing the `{ipfscid:version:codec:reserve:hash}` placeholder
+    /// - Returns: The extracted CID with version and codec determined from the template
+    /// - Throws: `ARCError.invalidReserveAddress` if the address cannot be decoded
     public static func extractCID(from address: String, templateUrl: String) throws -> CID {
         let params = try parseParamsFromTemplate(templateUrl)
         return try extractCID(from: address, params: params, validateChecksum: false)

--- a/Sources/ARC/ARC19/ARC19CID.swift
+++ b/Sources/ARC/ARC19/ARC19CID.swift
@@ -3,22 +3,117 @@ import Crypto
 
 /// Utilities for working with ARC-19 CID encoding in reserve addresses
 public enum ARC19CID {
-    /// Extract a CID from an Algorand reserve address
-    /// The CID is encoded in the public key part of the address
-    public static func extractCID(from address: String) throws -> CID {
-        // Decode the Algorand address
-        let decoded = try decodeAlgorandAddress(address)
+    /// Parameters parsed from an ARC-19 template placeholder
+    public struct TemplateParams: Sendable, Equatable {
+        public let version: CID.Version
+        public let codec: CID.Codec
+        public let hashAlgorithm: String
 
-        // The first 32 bytes are the public key (which contains the CID)
+        public init(version: CID.Version, codec: CID.Codec, hashAlgorithm: String = "sha2-256") {
+            self.version = version
+            self.codec = codec
+            self.hashAlgorithm = hashAlgorithm
+        }
+
+        /// Default parameters for CIDv0 dag-pb
+        public static let v0DagPB = TemplateParams(version: .v0, codec: .dagPB)
+
+        /// Default parameters for CIDv1 raw
+        public static let v1Raw = TemplateParams(version: .v1, codec: .raw)
+    }
+
+    /// Parse template parameters from an ARC-19 placeholder string
+    /// Format: {ipfscid:<version>:<codec>:reserve:<hash>}
+    /// Examples:
+    ///   - {ipfscid:0:dag-pb:reserve:sha2-256}
+    ///   - {ipfscid:1:raw:reserve:sha2-256}
+    public static func parseTemplateParams(from placeholder: String) throws -> TemplateParams {
+        // Remove braces if present
+        var content = placeholder
+        if content.hasPrefix("{") && content.hasSuffix("}") {
+            content = String(content.dropFirst().dropLast())
+        }
+
+        let parts = content.split(separator: ":")
+        guard parts.count >= 5,
+              parts[0] == "ipfscid",
+              parts[3] == "reserve"
+        else {
+            throw ARCError.invalidURL("Invalid ARC-19 template placeholder format: \(placeholder)")
+        }
+
+        // Parse version
+        let versionNum = Int(parts[1]) ?? 0
+        let version: CID.Version = versionNum == 1 ? .v1 : .v0
+
+        // Parse codec
+        let codecStr = String(parts[2])
+        let codec: CID.Codec
+        switch codecStr {
+        case "raw":
+            codec = .raw
+        case "dag-pb":
+            codec = .dagPB
+        case "dag-cbor":
+            codec = .dagCBOR
+        case "dag-json":
+            codec = .dagJSON
+        default:
+            throw ARCError.invalidURL("Unsupported codec in ARC-19 template: \(codecStr)")
+        }
+
+        // Parse hash algorithm
+        let hashAlgorithm = String(parts[4])
+
+        return TemplateParams(version: version, codec: codec, hashAlgorithm: hashAlgorithm)
+    }
+
+    /// Extract a CID from an Algorand reserve address
+    /// - Parameters:
+    ///   - address: The Algorand reserve address containing the encoded CID
+    ///   - params: Optional template parameters specifying CID version and codec
+    ///   - validateChecksum: Whether to validate the Algorand address checksum (default: false for ARC-19)
+    /// - Returns: The extracted CID
+    public static func extractCID(
+        from address: String,
+        params: TemplateParams = .v0DagPB,
+        validateChecksum: Bool = false
+    ) throws -> CID {
+        // Decode the Algorand address
+        let decoded = try decodeAlgorandAddress(address, validateChecksum: validateChecksum)
+
+        // The first 32 bytes are the public key (which contains the CID hash)
         guard decoded.count >= 32 else {
             throw ARCError.invalidReserveAddress("Address too short")
         }
 
-        let publicKey = decoded.prefix(32)
+        let hash = Data(decoded.prefix(32))
 
-        // For ARC-19, we expect a SHA-256 hash (32 bytes)
-        // This represents a CIDv0 (dag-pb)
-        return CID(version: .v0, codec: .dagPB, hash: Data(publicKey))
+        return CID(version: params.version, codec: params.codec, hash: hash)
+    }
+
+    /// Extract a CID from an Algorand reserve address using template URL to determine parameters
+    /// - Parameters:
+    ///   - address: The Algorand reserve address containing the encoded CID
+    ///   - templateUrl: The template URL containing the placeholder with version/codec info
+    /// - Returns: The extracted CID
+    public static func extractCID(from address: String, templateUrl: String) throws -> CID {
+        let params = try parseParamsFromTemplate(templateUrl)
+        return try extractCID(from: address, params: params, validateChecksum: false)
+    }
+
+    /// Parse template parameters from a full template URL
+    private static func parseParamsFromTemplate(_ templateUrl: String) throws -> TemplateParams {
+        // Find the placeholder pattern {ipfscid:...}
+        guard let startRange = templateUrl.range(of: "{ipfscid:"),
+              let endRange = templateUrl.range(of: "}", range: startRange.upperBound..<templateUrl.endIndex)
+        else {
+            // Default to v0 dag-pb if no placeholder found
+            return .v0DagPB
+        }
+
+        let placeholder = String(templateUrl[startRange.lowerBound...endRange.lowerBound])
+        return try parseTemplateParams(from: placeholder)
     }
 
     /// Encode a CID into an Algorand reserve address
@@ -33,7 +128,7 @@ public enum ARC19CID {
 
     // MARK: - Algorand Address Encoding/Decoding
 
-    private static func decodeAlgorandAddress(_ address: String) throws -> Data {
+    private static func decodeAlgorandAddress(_ address: String, validateChecksum: Bool) throws -> Data {
         // Algorand addresses are base32 encoded (without padding)
         // They contain: 32 bytes public key + 4 bytes checksum
 
@@ -60,16 +155,19 @@ public enum ARC19CID {
             throw ARCError.invalidReserveAddress("Invalid address length after decoding")
         }
 
-        // Verify checksum
         let publicKey = result.prefix(32)
-        let checksum = result.suffix(4)
-        let expectedChecksum = computeChecksum(publicKey)
 
-        guard checksum == expectedChecksum else {
-            throw ARCError.invalidReserveAddress("Invalid address checksum")
+        // Optionally verify checksum
+        if validateChecksum {
+            let checksum = result.suffix(4)
+            let expectedChecksum = computeChecksum(publicKey)
+
+            guard checksum == expectedChecksum else {
+                throw ARCError.invalidReserveAddress("Invalid address checksum")
+            }
         }
 
-        return publicKey
+        return Data(publicKey)
     }
 
     private static func encodeAlgorandAddress(_ publicKey: Data) throws -> String {

--- a/Sources/ARC/ARC19/ARC19Template.swift
+++ b/Sources/ARC/ARC19/ARC19Template.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// ARC-19: Templated URI for NFT Metadata
 public struct ARC19Template: ARCMetadata, Equatable {
-    /// The template URL (template-ipfs://{ipfscid:0:dag-pb:reserve:sha2-256}/path/{id})
+    /// The template URL (e.g., template-ipfs://{ipfscid:1:raw:reserve:sha2-256})
     public let templateUrl: String
 
     /// The reserve address containing the CID
@@ -11,23 +11,52 @@ public struct ARC19Template: ARCMetadata, Equatable {
     /// The parsed IPFS CID from the reserve address
     public let cid: CID
 
+    /// The parsed template parameters
+    public let templateParams: ARC19CID.TemplateParams
+
     public init(templateUrl: String, reserveAddress: String) throws {
         self.templateUrl = templateUrl
         self.reserveAddress = reserveAddress
-
-        // Extract and validate CID from reserve address
-        self.cid = try ARC19CID.extractCID(from: reserveAddress)
 
         // Validate template URL format
         guard templateUrl.hasPrefix("template-ipfs://") else {
             throw ARCError.invalidURL("ARC-19 template must use template-ipfs:// scheme")
         }
+
+        // Extract template parameters and CID from reserve address
+        self.templateParams = try ARC19CID.parseTemplateParams(from: Self.extractPlaceholder(from: templateUrl))
+        self.cid = try ARC19CID.extractCID(from: reserveAddress, params: templateParams, validateChecksum: false)
     }
 
     /// Create from a standard IPFS URL and reserve address
-    public init(ipfsUrl: IPFSUrl, reserveAddress: String, pathTemplate: String = "/{id}") throws {
-        let templateUrl = "template-ipfs://{ipfscid:0:dag-pb:reserve:sha2-256}\(pathTemplate)"
+    public init(
+        ipfsUrl: IPFSUrl,
+        reserveAddress: String,
+        pathTemplate: String = "/{id}",
+        cidVersion: CID.Version = .v0,
+        codec: CID.Codec = .dagPB
+    ) throws {
+        let codecString: String
+        switch codec {
+        case .raw: codecString = "raw"
+        case .dagPB: codecString = "dag-pb"
+        case .dagCBOR: codecString = "dag-cbor"
+        case .dagJSON: codecString = "dag-json"
+        }
+
+        let templateUrl = "template-ipfs://{ipfscid:\(cidVersion.rawValue):\(codecString):reserve:sha2-256}\(pathTemplate)"
         try self.init(templateUrl: templateUrl, reserveAddress: reserveAddress)
+    }
+
+    /// Extract the placeholder from a template URL
+    private static func extractPlaceholder(from templateUrl: String) throws -> String {
+        guard let startRange = templateUrl.range(of: "{ipfscid:"),
+              let endRange = templateUrl.range(of: "}", range: startRange.upperBound..<templateUrl.endIndex)
+        else {
+            throw ARCError.invalidURL("Template URL must contain {ipfscid:...} placeholder")
+        }
+
+        return String(templateUrl[startRange.lowerBound...endRange.lowerBound])
     }
 
     /// Resolve the template for a specific asset ID
@@ -35,9 +64,19 @@ public struct ARC19Template: ARCMetadata, Equatable {
         let cidString = cid.toString()
         var resolved = templateUrl
 
-        // Replace the template-ipfs placeholder
-        let templatePattern = "template-ipfs://{ipfscid:0:dag-pb:reserve:sha2-256}"
-        resolved = resolved.replacingOccurrences(of: templatePattern, with: "ipfs://\(cidString)")
+        // Build the placeholder pattern based on template params
+        let codecString: String
+        switch templateParams.codec {
+        case .raw: codecString = "raw"
+        case .dagPB: codecString = "dag-pb"
+        case .dagCBOR: codecString = "dag-cbor"
+        case .dagJSON: codecString = "dag-json"
+        }
+
+        let placeholder = "{ipfscid:\(templateParams.version.rawValue):\(codecString):reserve:\(templateParams.hashAlgorithm)}"
+
+        // Replace the template-ipfs:// scheme and placeholder with ipfs:// and CID
+        resolved = resolved.replacingOccurrences(of: "template-ipfs://\(placeholder)", with: "ipfs://\(cidString)")
 
         // Replace {id} with asset ID
         resolved = resolved.replacingOccurrences(of: "{id}", with: String(assetID))
@@ -70,15 +109,15 @@ public struct ARC19Template: ARCMetadata, Equatable {
             ))
         }
 
-        // Validate that template contains the required placeholder
-        if !templateUrl.contains("{ipfscid:0:dag-pb:reserve:sha2-256}") {
+        // Validate that template contains a valid placeholder
+        if !templateUrl.contains("{ipfscid:") {
             results.append(.failure(
                 field: "templateUrl",
-                message: "Must contain {ipfscid:0:dag-pb:reserve:sha2-256} placeholder"
+                message: "Must contain {ipfscid:...} placeholder"
             ))
         }
 
-        // Validate that template contains {id} placeholder
+        // Validate that template contains {id} placeholder (warning only)
         if !templateUrl.contains("{id}") {
             results.append(.warning(
                 field: "templateUrl",

--- a/Sources/ARC/ARC19/ARC19Template.swift
+++ b/Sources/ARC/ARC19/ARC19Template.swift
@@ -36,15 +36,7 @@ public struct ARC19Template: ARCMetadata, Equatable {
         cidVersion: CID.Version = .v0,
         codec: CID.Codec = .dagPB
     ) throws {
-        let codecString: String
-        switch codec {
-        case .raw: codecString = "raw"
-        case .dagPB: codecString = "dag-pb"
-        case .dagCBOR: codecString = "dag-cbor"
-        case .dagJSON: codecString = "dag-json"
-        }
-
-        let templateUrl = "template-ipfs://{ipfscid:\(cidVersion.rawValue):\(codecString):reserve:sha2-256}\(pathTemplate)"
+        let templateUrl = "template-ipfs://{ipfscid:\(cidVersion.rawValue):\(codec.templateString):reserve:sha2-256}\(pathTemplate)"
         try self.init(templateUrl: templateUrl, reserveAddress: reserveAddress)
     }
 
@@ -56,7 +48,7 @@ public struct ARC19Template: ARCMetadata, Equatable {
             throw ARCError.invalidURL("Template URL must contain {ipfscid:...} placeholder")
         }
 
-        return String(templateUrl[startRange.lowerBound...endRange.lowerBound])
+        return String(templateUrl[startRange.lowerBound..<endRange.upperBound])
     }
 
     /// Resolve the template for a specific asset ID
@@ -65,15 +57,7 @@ public struct ARC19Template: ARCMetadata, Equatable {
         var resolved = templateUrl
 
         // Build the placeholder pattern based on template params
-        let codecString: String
-        switch templateParams.codec {
-        case .raw: codecString = "raw"
-        case .dagPB: codecString = "dag-pb"
-        case .dagCBOR: codecString = "dag-cbor"
-        case .dagJSON: codecString = "dag-json"
-        }
-
-        let placeholder = "{ipfscid:\(templateParams.version.rawValue):\(codecString):reserve:\(templateParams.hashAlgorithm)}"
+        let placeholder = "{ipfscid:\(templateParams.version.rawValue):\(templateParams.codec.templateString):reserve:\(templateParams.hashAlgorithm)}"
 
         // Replace the template-ipfs:// scheme and placeholder with ipfs:// and CID
         resolved = resolved.replacingOccurrences(of: "template-ipfs://\(placeholder)", with: "ipfs://\(cidString)")

--- a/Sources/ARC/IPFS/CID.swift
+++ b/Sources/ARC/IPFS/CID.swift
@@ -258,6 +258,32 @@ private enum Base58 {
     }
 }
 
+// MARK: - Codec String Conversion
+
+extension CID.Codec {
+    /// The string representation used in ARC-19 template URLs
+    public var templateString: String {
+        switch self {
+        case .raw: return "raw"
+        case .dagPB: return "dag-pb"
+        case .dagCBOR: return "dag-cbor"
+        case .dagJSON: return "dag-json"
+        }
+    }
+
+    /// Initialize from an ARC-19 template string
+    public init(templateString: String) throws {
+        switch templateString {
+        case "raw": self = .raw
+        case "dag-pb": self = .dagPB
+        case "dag-cbor": self = .dagCBOR
+        case "dag-json": self = .dagJSON
+        default:
+            throw ARCError.invalidURL("Unsupported codec in ARC-19 template: \(templateString)")
+        }
+    }
+}
+
 // MARK: - Base32 Encoder/Decoder (RFC 4648 lowercase)
 
 private enum Base32 {

--- a/Tests/ARCTests/ARC19Tests.swift
+++ b/Tests/ARCTests/ARC19Tests.swift
@@ -229,6 +229,86 @@ final class ARC19Tests: XCTestCase {
         XCTAssertEqual(template.cid.codec, .raw)
     }
 
+    func testCIDv1RawCodecResolve() throws {
+        // Create a CIDv1 raw codec
+        let hash = Data(repeating: 99, count: 32)
+        let cid = CID(version: .v1, codec: .raw, hash: hash)
+        let reserveAddress = try ARC19CID.encodeToReserveAddress(cid: cid)
+
+        let template = try ARC19Template(
+            templateUrl: "template-ipfs://{ipfscid:1:raw:reserve:sha2-256}/nft/{id}",
+            reserveAddress: reserveAddress
+        )
+
+        let resolved = try template.resolve(assetID: 42)
+
+        // Should start with ipfs:// and contain the CIDv1 (starts with 'b')
+        XCTAssertTrue(resolved.hasPrefix("ipfs://b"), "Resolved URL should use CIDv1 format")
+        XCTAssertTrue(resolved.contains("/nft/42"), "Resolved URL should contain asset ID")
+    }
+
+    func testExtractCIDFromTemplateUrl() throws {
+        // Create a CID and encode to reserve address
+        let hash = Data(repeating: 55, count: 32)
+        let originalCID = CID(version: .v1, codec: .raw, hash: hash)
+        let reserveAddress = try ARC19CID.encodeToReserveAddress(cid: originalCID)
+
+        // Use the template URL overload
+        let extractedCID = try ARC19CID.extractCID(
+            from: reserveAddress,
+            templateUrl: "template-ipfs://{ipfscid:1:raw:reserve:sha2-256}/metadata/{id}"
+        )
+
+        XCTAssertEqual(extractedCID.version, .v1)
+        XCTAssertEqual(extractedCID.codec, .raw)
+        XCTAssertEqual(extractedCID.hash, hash)
+    }
+
+    func testExtractCIDFromTemplateUrlDefaultsToV0() throws {
+        // Create a CIDv0
+        let hash = Data(repeating: 33, count: 32)
+        let originalCID = CID(version: .v0, codec: .dagPB, hash: hash)
+        let reserveAddress = try ARC19CID.encodeToReserveAddress(cid: originalCID)
+
+        // Use a template URL without a valid placeholder (should default to v0 dag-pb)
+        let extractedCID = try ARC19CID.extractCID(
+            from: reserveAddress,
+            templateUrl: "ipfs://some-url-without-placeholder"
+        )
+
+        XCTAssertEqual(extractedCID.version, .v0)
+        XCTAssertEqual(extractedCID.codec, .dagPB)
+        XCTAssertEqual(extractedCID.hash, hash)
+    }
+
+    func testParseTemplateParamsInvalidHashAlgorithm() throws {
+        XCTAssertThrowsError(
+            try ARC19CID.parseTemplateParams(from: "{ipfscid:1:raw:reserve:sha3-256}")
+        ) { error in
+            if let arcError = error as? ARCError,
+               case .invalidURL(let message) = arcError {
+                XCTAssertTrue(message.contains("Unsupported hash algorithm"))
+                XCTAssertTrue(message.contains("sha2-256"))
+            } else {
+                XCTFail("Expected ARCError.invalidURL for invalid hash algorithm")
+            }
+        }
+    }
+
+    func testParseTemplateParamsExtraPartsRejected() throws {
+        // Extra parts should now be rejected with strict validation
+        XCTAssertThrowsError(
+            try ARC19CID.parseTemplateParams(from: "{ipfscid:1:raw:reserve:sha2-256:extra:parts}")
+        ) { error in
+            if let arcError = error as? ARCError,
+               case .invalidURL(let message) = arcError {
+                XCTAssertTrue(message.contains("Invalid ARC-19 template placeholder format"))
+            } else {
+                XCTFail("Expected ARCError.invalidURL for extra parts")
+            }
+        }
+    }
+
     func testParseTemplateParamsV0DagPB() throws {
         let params = try ARC19CID.parseTemplateParams(from: "{ipfscid:0:dag-pb:reserve:sha2-256}")
 

--- a/Tests/ARCTests/ARC19Tests.swift
+++ b/Tests/ARCTests/ARC19Tests.swift
@@ -210,6 +210,142 @@ final class ARC19Tests: XCTestCase {
         XCTAssertEqual(extractedCID.hash, originalCID.hash)
     }
 
+    // MARK: - CIDv1 and Template Params Tests
+
+    func testCIDv1RawCodecTemplate() throws {
+        // Create a CIDv1 raw codec
+        let hash = Data(repeating: 99, count: 32)
+        let cid = CID(version: .v1, codec: .raw, hash: hash)
+        let reserveAddress = try ARC19CID.encodeToReserveAddress(cid: cid)
+
+        let template = try ARC19Template(
+            templateUrl: "template-ipfs://{ipfscid:1:raw:reserve:sha2-256}",
+            reserveAddress: reserveAddress
+        )
+
+        XCTAssertEqual(template.templateParams.version, .v1)
+        XCTAssertEqual(template.templateParams.codec, .raw)
+        XCTAssertEqual(template.cid.version, .v1)
+        XCTAssertEqual(template.cid.codec, .raw)
+    }
+
+    func testParseTemplateParamsV0DagPB() throws {
+        let params = try ARC19CID.parseTemplateParams(from: "{ipfscid:0:dag-pb:reserve:sha2-256}")
+
+        XCTAssertEqual(params.version, .v0)
+        XCTAssertEqual(params.codec, .dagPB)
+        XCTAssertEqual(params.hashAlgorithm, "sha2-256")
+    }
+
+    func testParseTemplateParamsV1Raw() throws {
+        let params = try ARC19CID.parseTemplateParams(from: "{ipfscid:1:raw:reserve:sha2-256}")
+
+        XCTAssertEqual(params.version, .v1)
+        XCTAssertEqual(params.codec, .raw)
+        XCTAssertEqual(params.hashAlgorithm, "sha2-256")
+    }
+
+    func testParseTemplateParamsAllCodecs() throws {
+        let codecs: [(String, CID.Codec)] = [
+            ("raw", .raw),
+            ("dag-pb", .dagPB),
+            ("dag-cbor", .dagCBOR),
+            ("dag-json", .dagJSON)
+        ]
+
+        for (str, expected) in codecs {
+            let params = try ARC19CID.parseTemplateParams(from: "{ipfscid:1:\(str):reserve:sha2-256}")
+            XCTAssertEqual(params.codec, expected, "Codec \(str) should parse to \(expected)")
+        }
+    }
+
+    func testParseTemplateParamsInvalidVersion() throws {
+        XCTAssertThrowsError(
+            try ARC19CID.parseTemplateParams(from: "{ipfscid:5:raw:reserve:sha2-256}")
+        ) { error in
+            if let arcError = error as? ARCError,
+               case .invalidURL(let message) = arcError {
+                XCTAssertTrue(message.contains("Unsupported CID version"))
+            } else {
+                XCTFail("Expected ARCError.invalidURL for invalid version")
+            }
+        }
+    }
+
+    func testParseTemplateParamsInvalidCodec() throws {
+        XCTAssertThrowsError(
+            try ARC19CID.parseTemplateParams(from: "{ipfscid:1:invalid-codec:reserve:sha2-256}")
+        ) { error in
+            if let arcError = error as? ARCError,
+               case .invalidURL(let message) = arcError {
+                XCTAssertTrue(message.contains("Unsupported codec"))
+            } else {
+                XCTFail("Expected ARCError.invalidURL for invalid codec")
+            }
+        }
+    }
+
+    func testExtractCIDWithValidateChecksumEnabled() throws {
+        // Create a valid address with correct checksum
+        let hash = Data(repeating: 42, count: 32)
+        let cid = CID(version: .v0, codec: .dagPB, hash: hash)
+        let validAddress = try ARC19CID.encodeToReserveAddress(cid: cid)
+
+        // Should succeed with checksum validation enabled (valid address)
+        let extracted = try ARC19CID.extractCID(from: validAddress, validateChecksum: true)
+        XCTAssertEqual(extracted.hash, hash)
+    }
+
+    func testExtractCIDWithValidateChecksumDisabled() throws {
+        // Create a valid address
+        let hash = Data(repeating: 42, count: 32)
+        let cid = CID(version: .v0, codec: .dagPB, hash: hash)
+        let validAddress = try ARC19CID.encodeToReserveAddress(cid: cid)
+
+        // Should succeed with checksum validation disabled
+        let extracted = try ARC19CID.extractCID(from: validAddress, validateChecksum: false)
+        XCTAssertEqual(extracted.hash, hash)
+    }
+
+    func testExtractCIDv1FromReserveAddress() throws {
+        let hash = Data(repeating: 77, count: 32)
+        let originalCID = CID(version: .v1, codec: .raw, hash: hash)
+        let reserveAddress = try ARC19CID.encodeToReserveAddress(cid: originalCID)
+
+        let extractedCID = try ARC19CID.extractCID(
+            from: reserveAddress,
+            params: .v1Raw
+        )
+
+        XCTAssertEqual(extractedCID.version, .v1)
+        XCTAssertEqual(extractedCID.codec, .raw)
+        XCTAssertEqual(extractedCID.hash, hash)
+    }
+
+    func testCodecTemplateStringRoundTrip() throws {
+        let codecs: [CID.Codec] = [.raw, .dagPB, .dagCBOR, .dagJSON]
+
+        for codec in codecs {
+            let str = codec.templateString
+            let parsed = try CID.Codec(templateString: str)
+            XCTAssertEqual(parsed, codec, "Codec \(codec) should round-trip through templateString")
+        }
+    }
+
+    func testCodecTemplateStringValues() {
+        XCTAssertEqual(CID.Codec.raw.templateString, "raw")
+        XCTAssertEqual(CID.Codec.dagPB.templateString, "dag-pb")
+        XCTAssertEqual(CID.Codec.dagCBOR.templateString, "dag-cbor")
+        XCTAssertEqual(CID.Codec.dagJSON.templateString, "dag-json")
+    }
+
+    func testTemplateParamsPresets() {
+        XCTAssertEqual(ARC19CID.TemplateParams.v0DagPB.version, .v0)
+        XCTAssertEqual(ARC19CID.TemplateParams.v0DagPB.codec, .dagPB)
+        XCTAssertEqual(ARC19CID.TemplateParams.v1Raw.version, .v1)
+        XCTAssertEqual(ARC19CID.TemplateParams.v1Raw.codec, .raw)
+    }
+
     // MARK: - JSON Encoding/Decoding Tests
 
     func testJSONEncoding() throws {


### PR DESCRIPTION
## Summary

- Skip checksum validation by default for ARC-19 reserve addresses (the CID itself provides data integrity)
- Add support for parsing CID version and codec from template URL (e.g., `{ipfscid:1:raw:reserve:sha2-256}`)
- Support CIDv1 with raw codec in addition to CIDv0 dag-pb
- Add `ARC19CID.TemplateParams` struct for parsed template parameters
- Update `ARC19Template` to use template URL for CID extraction

## Test plan

- [x] All 98 existing swift-arc tests pass
- [x] Tested with swift-nft-downloader against real NFT collections:
  - **Corvid collection** (145 NFTs): Previously failed with "Invalid address checksum", now successfully resolves all ARC-19 templates
  - **Nature collection** (40 NFTs): Works with direct IPFS URLs

## Before/After

**Before:** 
```
Downloaded 0 images from address 1 (ARC-19 parsing failed)
```

**After:**
```
Downloaded 145 images from address 1 (2.2 seconds)
```

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)